### PR TITLE
Update dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ exports.register = function (server, options, next) {
 
     const plugins = [{
         register: Fischbacher,
-        options: options
+        options
     }, {
         register: Recourier,
         options: {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "homepage": "https://github.com/ruiquelhas/coutts#readme",
   "devDependencies": {
-    "code": "3.x.x",
+    "code": "4.x.x",
     "content": "3.x.x",
     "coveralls": "2.x.x",
-    "hapi": "13.x.x",
-    "lab": "10.x.x",
-    "multi-part": "1.x.x"
+    "hapi": "15.x.x",
+    "lab": "11.x.x",
+    "multi-part": "2.x.x"
   },
   "dependencies": {
     "fischbacher": "2.x.x",
@@ -43,6 +43,6 @@
     "subtext": "4.x.x"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.5.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -81,7 +81,7 @@ lab.experiment('coutts', () => {
         const form = new Form();
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.get(), url: '/main' }, (response) => {
+        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/main' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             Code.expect(response.headers['content-validation']).to.equal('success');
@@ -99,7 +99,7 @@ lab.experiment('coutts', () => {
         const form = new Form();
         form.append('file', Fs.createReadStream(png));
 
-        server.inject({ headers: { 'Content-Type': 'application/json' }, method: 'POST', payload: form.get(), url: '/main' }, (response) => {
+        server.inject({ headers: { 'Content-Type': 'application/json' }, method: 'POST', payload: form.stream(), url: '/main' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(415);
             Code.expect(response.headers['content-validation']).to.not.exist();
@@ -119,7 +119,7 @@ lab.experiment('coutts', () => {
         form.append('file2', Fs.createReadStream(png));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.get(), url: '/main' }, (response) => {
+        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/main' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             Code.expect(response.headers['content-validation']).to.equal('success');

--- a/test/index.js
+++ b/test/index.js
@@ -94,7 +94,7 @@ lab.experiment('coutts', () => {
     lab.test('should return error if the payload cannot be parsed', (done) => {
 
         const png = Path.join(Os.tmpdir(), 'foo.png');
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
 
         const form = new Form();
         form.append('file', Fs.createReadStream(png));
@@ -112,7 +112,7 @@ lab.experiment('coutts', () => {
     lab.test('should return control to the server if all files the in payload are allowed', (done) => {
 
         const png = Path.join(Os.tmpdir(), 'foo.png');
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
 
         const form = new Form();
         form.append('file1', Fs.createReadStream(png));


### PR DESCRIPTION
Update 3rd-party modules and supported node engine. Switch to the new `Buffer` API available since `v4.5.0`.